### PR TITLE
breaking change with in-repo PR

### DIFF
--- a/subgraphs/products/products.graphql
+++ b/subgraphs/products/products.graphql
@@ -18,7 +18,6 @@ type ProductDimension {
 }
 
 extend type Query {
-  allProducts: [Product]
   product(id: ID!): Product
 }
 


### PR DESCRIPTION
demonstrates breaking schema change on `products` subgraph.

Signed-off-by: Phil Prasek <prasek@gmail.com>