### PR TITLE
fix: #136 - docker-compose.managed.yml not working with user-defined graph

### DIFF
--- a/.scripts/get-env.sh
+++ b/.scripts/get-env.sh
@@ -1,16 +1,27 @@
 #!/bin/bash 
- 
-eval "$(cat graph-api.env)"
-if [[ -z "${APOLLO_KEY}" ]]; then
+
+if ls graph-api.env > /dev/null 2>&1; then
+  eval "$(cat graph-api.env)"
+fi
+
+if [[ -z "${APOLLO_KEY}" || -z "${APOLLO_GRAPH_REF}" ]]; then
   source "$(dirname $0)/graph-api-env.sh"
   eval "$(cat graph-api.env)"
 
   if [[ -z "${APOLLO_KEY}" ]]; then
     echo -------------------------------------------------------------------------------------------
-    echo environment keyfile required, run: make graph-api-key
+    echo APOLLO_KEY not found, run: make graph-api-env
+    echo -------------------------------------------------------------------------------------------
+    exit 1
+  fi
+
+  if [[ -z "${APOLLO_GRAPH_REF}" ]]; then
+    echo -------------------------------------------------------------------------------------------
+    echo APOLLO_GRAPH_REF not found, run: make graph-api-env
     echo -------------------------------------------------------------------------------------------
     exit 1
   fi
 fi
 
 export APOLLO_KEY=$APOLLO_KEY
+export APOLLO_GRAPH_REF=$APOLLO_GRAPH_REF

--- a/.scripts/get-graph-ref.sh
+++ b/.scripts/get-graph-ref.sh
@@ -8,10 +8,18 @@ echo "then copy your Graph NAME and optionally @<VARIANT> and enter it at the pr
 echo "@<VARIANT> will default to @current, if omitted."
 echo ""
 echo "Enter the <NAME>@<VARIANT> of a federated graph in Apollo Studio:"
+if [[ -n "$APOLLO_GRAPH_REF" ]]; then
+  echo ""
+  echo "press <enter> for default: $APOLLO_GRAPH_REF"
+fi
 read -p "> " graph
 if [[ -z "$graph" ]]; then
+  if [[ -n "$APOLLO_GRAPH_REF" ]]; then
+    graph=$APOLLO_GRAPH_REF
+  else
     >&2 echo "Error: no graph ref specified."
     exit 1
+  fi
 fi
 
 export graph=$graph

--- a/.scripts/graph-api-env.sh
+++ b/.scripts/graph-api-env.sh
@@ -1,16 +1,40 @@
 #!/bin/bash
 
+if ls graph-api.env > /dev/null 2>&1; then
+  eval "$(cat graph-api.env)"
+fi
+
 echo -------------------------------------------------------------------------------------------
 echo Enter your Graph API Key
 echo -------------------------------------------------------------------------------------------
 echo "Go to your graph settings in https://studio.apollographql.com/"
 echo "then create a Graph API Key with Contributor permissions"
 echo "(for metrics reporting) and enter it at the prompt below."
+
+if [[ -n "$APOLLO_KEY" ]]; then
+  echo ""
+  echo "press <enter> to use existing key: *************** (from ./graph-api.env)"
+fi
+
 read -s -p "> " key
 echo
 if [[ -z "$key" ]]; then
+  if [[ -n "$APOLLO_KEY" ]]; then
+    key=$APOLLO_KEY
+  else
     >&2 echo "Error: no key specified."
     exit 1
+  fi
 fi
 
 echo "APOLLO_KEY=${key}" > graph-api.env
+
+# --------------------------------------------------------------------------
+# APOLLO_GRAPH_REF
+# --------------------------------------------------------------------------
+echo ""
+if [[ -z "${graph}" ]]; then
+  source "$(dirname $0)/get-graph-ref.sh"
+fi
+
+echo "APOLLO_GRAPH_REF=${graph}" >> graph-api.env

--- a/.scripts/publish.sh
+++ b/.scripts/publish.sh
@@ -3,7 +3,15 @@
 source "$(dirname $0)/subgraphs.sh"
 source "$(dirname $0)/get-env.sh"
 
-graph=$1
+if [[ "$1" == "default" ]]; then
+  if [[ -n $APOLLO_GRAPH_REF ]]; then
+    graph=$APOLLO_GRAPH_REF
+    echo -------------------------------------------------------------------------------------------
+    echo "using: ${graph}"
+    echo -------------------------------------------------------------------------------------------
+  fi
+fi
+
 if [[ -z "${graph}" ]]; then
   source "$(dirname $0)/get-graph-ref.sh"
 fi

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ci: supergraph docker-up smoke docker-down
 demo: supergraph docker-up query docker-down
 
 .PHONY: demo-managed
-demo-managed: publish docker-up-managed query docker-down
+demo-managed: ensure-graph-api-env publish-default docker-up-managed query docker-down
 
 .PHONY: demo-k8s
 demo-k8s: k8s-up k8s-smoke k8s-down
@@ -52,6 +52,10 @@ compose:
 publish:
 	.scripts/publish.sh
 
+.PHONY: publish-default
+publish-default:
+	.scripts/publish.sh default
+
 .PHONY: unpublish
 unpublish:
 	.scripts/unpublish.sh
@@ -59,6 +63,10 @@ unpublish:
 .PHONY: graph-api-env
 graph-api-env:
 	@.scripts/graph-api-env.sh
+
+.PHONY: ensure-graph-api-env
+ensure-graph-api-env:
+	@.scripts/get-env.sh
 
 .PHONY: check-products
 check-products:

--- a/docker-compose.managed.yml
+++ b/docker-compose.managed.yml
@@ -5,7 +5,6 @@ services:
     build: ./router
     environment:
       - APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT=https://uplink.api.apollographql.com/
-      - APOLLO_GRAPH_REF=supergraph-router@dev
     env_file: # create with make graph-api-env
       - graph-api.env
     ports:


### PR DESCRIPTION
* Fixes #136
  * `./graph-api.env` now contains `APOLLO_GRAPH_REF` for use in `docker-compose` and the `make` commands.
  * `APOLLO_GRAPH_REF` was previously hardcoded in the `docker-compose.manage.yaml` 
* Fixes #9
  * `make demo-managed` now uses the `./graph-api.env` created via `make graph-api-env` to override local settings if `./graph-api.env` is present.
  * APOLLO_KEY and APOLLO_GRAPH_REF will flow though if `./graph-api.env` doesn't exist - but note that `./graph-api-env` is now created automatically (via prompts) when running `make demo-managed` and other `make` commands, so you need to ensure the `./graph-api.env` doesn't exist if you want externally set APOLLO_KEY and APOLLO_GRAPH_REF to flow through.

Signed-off-by: Phil Prasek <prasek@gmail.com>