### PR TITLE
pin otel collector 0.42.0 for /v1/trace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,13 @@ docker-up-otel-collector:
 	@sleep 2
 	docker-compose -f docker-compose.otel-collector.yml logs
 
+.PHONY: docker-up-local-router-otel
+docker-up-local-router-otel:
+	docker-compose -f docker-compose.router-otel.yml up -d
+	@sleep 2
+	docker-compose -f docker-compose.router-otel.yml logs
+
+
 .PHONY: docker-down-otel-collector
 docker-down-otel-collector:
 	docker-compose -f docker-compose.otel-collector.yml down

--- a/docker-compose.router-otel.yml
+++ b/docker-compose.router-otel.yml
@@ -1,14 +1,11 @@
 version: '3'
 services:
-  apollo-gateway:
-    container_name: apollo-gateway
-    build: ./gateway
-    environment:
-      - APOLLO_SCHEMA_CONFIG_EMBEDDED=true
-      - APOLLO_OTEL_EXPORTER_TYPE=collector
-      - APOLLO_OTEL_EXPORTER_HOST=collector
+  apollo-router:
+    container_name: apollo-router
+    build: ./router
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
+      - ./router/configuration.yaml:/etc/config/configuration.yaml
     ports:
       - "4000:4000"
   products:

--- a/opentelemetry/collector-config.yml
+++ b/opentelemetry/collector-config.yml
@@ -3,9 +3,10 @@ receivers:
     protocols:
       grpc:
       http:
-        cors_allowed_origins:
-          - http://*
-          - https://*
+        cors:
+          allowed_origins:
+            - http://*
+            - https://*
 
 exporters:
   zipkin:
@@ -16,7 +17,12 @@ exporters:
 processors:
   batch:
 
+extensions:
+  zpages:
+    endpoint: 0.0.0.0:55679
+
 service:
+  extensions: [zpages]
   pipelines:
     traces:
       receivers: [otlp]

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
     "workarounds:all"
   ],
   "packageRules": [
-     {  "automerge": true, "automergeType": "pr", "matchUpdateTypes": ["minor", "patch", "pin", "digest"]}
+     {  "automerge": true, "excludePackageNames":"otel/opentelemetry-collector", "matchUpdateTypes": ["minor", "patch", "pin", "digest"]},
+     {  "automerge": false, "matchPackageNames":"otel/opentelemetry-collector", "matchUpdateTypes": ["minor", "patch", "pin", "digest"]}
   ]
 }


### PR DESCRIPTION
- See related https://github.com/apollographql/supergraph-demo-fed2/pull/44
- Pinning to otel/opentelemetry-collector 0.42.0 which supports the deprecated `/v1/trace`
- From: https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.43.0
  - Remove deprecated legacy path ("v1/trace") support for otlp http receiver (https://github.com/open-telemetry/opentelemetry-collector/pull/4720)
- With otel/opentelemetry-collector 0.43.0:
  - http://localhost:55679/debug/tracez shows error samples with http.status_code=404, http.target=/v1/trace

<details><summary>Error Trace Spans</summary>

```
3 Requests

When                       Elapsed (sec)
----------------------------------------
2022/02/10-02:39:24.916957      .    77 trace_id: a8f6732587ff36e0e1b45c5c6e335322 span_id: 6aa3347a98d8cbbc
                                        Status{Code=Error, description=""}
                                        Attributes:{http.flavor=1.1, http.host=collector:55681, http.method=POST, http.request_content_length=5047, http.scheme=http, http.status_code=404, http.target=/v1/trace, http.wrote_bytes=19, net.host.name=collector, net.host.port=55681, net.peer.ip=172.22.0.2, net.peer.port=41562, net.transport=ip_tcp}
2022/02/10-02:39:32.619622      .    35 trace_id: 944f49a15fd55768af3df35c7f965a3f span_id: 67bb4fd243bc30ef
                                        Status{Code=Error, description=""}
                                        Attributes:{http.flavor=1.1, http.host=collector:55681, http.method=POST, http.request_content_length=30437, http.scheme=http, http.status_code=404, http.target=/v1/trace, http.wrote_bytes=19, net.host.name=collector, net.host.port=55681, net.peer.ip=172.22.0.6, net.peer.port=59220, net.transport=ip_tcp}
2022/02/10-02:39:35.647788      .    41 trace_id: 9e672ce2916c5e67929e3254dc8c3b08 span_id: c00e14f481d47c0d
                                        Status{Code=Error, description=""}
                                        Attributes:{http.flavor=1.1, http.host=collector:55681, http.method=POST, http.request_content_length=29390, http.scheme=http, http.status_code=404, http.target=/v1/trace, http.wrote_bytes=19, net.host.name=collector, net.host.port=55681, net.peer.ip=172.22.0.6, net.peer.port=59220, net.transport=ip_tcp}

TraceId means sampled request. TraceId means not sampled request.
```

</summary>

Signed-off-by: Phil Prasek <prasek@gmail.com>

Signed-off-by: Phil Prasek <prasek@gmail.com>