### PR TITLE
chore: sets federation_version to 1

### DIFF
--- a/supergraph.yaml
+++ b/supergraph.yaml
@@ -1,3 +1,4 @@
+federation_version: 1
 subgraphs:
   inventory:
     routing_url: http://inventory:4000/graphql


### PR DESCRIPTION
https://github.com/apollographql/rover/pull/1058 makes `rover supergraph compose` default to federation 2.