### PR TITLE
fix rover error handling

### DIFF
--- a/.scripts/publish.sh
+++ b/.scripts/publish.sh
@@ -1,17 +1,25 @@
 #!/bin/bash 
 
 echo "======================================="
-echo "SUBGRAPH PUBLISH"
+echo "PUBLISH SUBGRAPHS TO APOLLO REGISTRY"
 echo "======================================="
 
 source "$(dirname $0)/subgraphs.sh"
 source "$(dirname $0)/graph-api-env.sh"
+
+# note: use --allow-invalid-routing-url to allow localhost without confirmation prompt
 
 for subgraph in ${subgraphs[@]}; do
   echo "---------------------------------------"
   echo "subgraph: ${subgraph}"
   echo "---------------------------------------"
   url="url_$subgraph"
-  (set -x; ${ROVER_BIN:-'rover'} subgraph publish ${APOLLO_GRAPH_REF} --routing-url "${!url}" --schema subgraphs/${subgraph}/${subgraph}.graphql --name ${subgraph} --convert)
+  schema="subgraphs/$subgraph/$subgraph.graphql"
+  (set -x; ${ROVER_BIN:-'rover'} subgraph publish ${APOLLO_GRAPH_REF} \
+    --routing-url "${!url}" \
+    --schema "${schema}" \
+    --name ${subgraph} \
+    --allow-invalid-routing-url \
+    --convert)
   echo ""
 done

--- a/.scripts/unpublish.sh
+++ b/.scripts/unpublish.sh
@@ -17,6 +17,10 @@ if grep -Eq 'error:(.+) Graph has no implementing services' unpublish.log; then
   echo "Success, all subgraphs removed!"
   rm unpublish.log
   exit 0
+elif grep -Eq 'error:(.+) invalid input syntax for uuid: ""' unpublish.log; then
+  echo "Success, no subgraphs found!"
+  rm unpublish.log
+  exit 0
 else
   cat unpublish.log
   rm unpublish.log


### PR DESCRIPTION
New `rover` behavior addressed in `make publish` and `make unpublish`:
- `rover subgraph publish` no longer accepts `localhost` without confirmation
   - unless you use the new `--allow-invalid-routing-url` flag.
- When no subgraphs found, previously `error: Graph has no implementing services` was returned
   - now `error: invalid input syntax for uuid: ""` is returned.